### PR TITLE
Use get_phantom_base_url instead of 127.0.0.1

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,3 @@
 **Unreleased**
 
-* chore(ci): update pre-commit config
 * Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Use get_phantom_base_url instead of 127.0.0.1

--- a/runner.json
+++ b/runner.json
@@ -437,11 +437,5 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ],
-    "custom_made": true,
-    "directory": "runner_3f141df7-4bf2-40de-8f68-6133a2cabf11",
-    "version": 1,
-    "appname": "-",
-    "executable": "spawn3",
-    "disabled": false
+    ]
 }

--- a/runner_connector.py
+++ b/runner_connector.py
@@ -56,18 +56,13 @@ class RunnerConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("Start", True)
-        port = 443
-        base_url = "https://127.0.0.1"
-        try:
-            port = self.get_config().get("https_port")
-        except:
-            pass
         try:
             base_url = self.get_config().get("cluster_base_url")
+            port = self.get_config().get("https_port")
+            self.__print(f"Base URL: {base_url}:{port}", True)
+            return f"{base_url}:{port}"
         except:
-            pass
-        self.__print(f"Base URL: {base_url}:{port}", True)
-        return f"{base_url}:{port}"
+            return self.get_phantom_base_url()
 
     def _get_rest_data(self, endpoint):
         self.__print("Start", True)

--- a/runner_connector.py
+++ b/runner_connector.py
@@ -56,12 +56,14 @@ class RunnerConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("Start", True)
-        try:
-            base_url = self.get_config().get("cluster_base_url")
+        base_url = self.get_config().get("cluster_base_url")
+        if base_url:
             port = self.get_config().get("https_port")
+            if not port:
+                port = 443
             self.__print(f"Base URL: {base_url}:{port}", True)
             return f"{base_url}:{port}"
-        except:
+        else:
             return self.get_phantom_base_url()
 
     def _get_rest_data(self, endpoint):


### PR DESCRIPTION
### Bug Fixes
- Fixes SOARHELP-4543 by removing the hard-coded 127.0.0.1

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
