### PR TITLE
fix: verify Runner API certificates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Mhike, 2022-2025
+   Copyright (c) Mhike, 2022-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Runner
-Copyright (c) Mhike, 2022-2025
+Copyright (c) Mhike, 2022-2026

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **cluster_base_url** | optional | string | The base URL to use in a cluster environment |
 **cluster_api_token** | optional | password | An API token for a cluster environment |
 **debug** | optional | boolean | Print debugging statements to log |
+**verify_server_cert** | optional | boolean | Verify the server certificate for HTTPS connections |
 
 ### Supported Actions
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) Mhike, 2022-2025
+# Copyright (c) Mhike, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* chore: refresh connector development tooling (Written by Codex)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* chore: refresh connector development tooling (Written by Codex)
+* PAPP-38039: Verify server certificates by default for Runner API requests (Written by Codex)

--- a/runner.json
+++ b/runner.json
@@ -10,7 +10,7 @@
     "python_version": "3",
     "product_version_regex": ".*",
     "publisher": "Mhike",
-    "license": "Copyright (c) Mhike, 2022-2025",
+    "license": "Copyright (c) Mhike, 2022-2026",
     "app_version": "1.1.1",
     "utctime_updated": "2025-08-06T22:51:25.699924Z",
     "package_name": "phantom_runner",

--- a/runner.json
+++ b/runner.json
@@ -63,6 +63,14 @@
             "order": 4,
             "name": "debug",
             "id": 4
+        },
+        "verify_server_cert": {
+            "description": "Verify the server certificate for HTTPS connections",
+            "data_type": "boolean",
+            "default": true,
+            "order": 5,
+            "name": "verify_server_cert",
+            "id": 5
         }
     },
     "actions": [
@@ -437,5 +445,11 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/runner_connector.py
+++ b/runner_connector.py
@@ -32,6 +32,7 @@ class RunnerConnector(phantom.BaseConnector):
 
     def __init__(self):
         super().__init__()
+        self._verify_server_cert = True
         return
 
     def __print(self, value, is_debug=False):
@@ -73,9 +74,9 @@ class RunnerConnector(phantom.BaseConnector):
             url = f"{self._get_base_url()}/{endpoint}"
             self.__print(url, True)
             if self.session:
-                response = self.session.get(url, verify=False)
+                response = self.session.get(url, verify=self._verify_server_cert)
             else:
-                response = phantom.requests.get(url, verify=False)
+                response = phantom.requests.get(url, verify=self._verify_server_cert)
             content = json.loads(response.text)
             code = response.status_code
             if 199 < code < 300:
@@ -100,9 +101,9 @@ class RunnerConnector(phantom.BaseConnector):
             self.__print(url, True)
             data = json.dumps(dictionary)
             if self.session:
-                response = self.session.post(url, data=data, verify=False)
+                response = self.session.post(url, data=data, verify=self._verify_server_cert)
             else:
-                response = phantom.requests.post(url, data=data, verify=False)
+                response = phantom.requests.post(url, data=data, verify=self._verify_server_cert)
             content = response.text
             code = response.status_code
             if 199 < code < 300:
@@ -313,9 +314,9 @@ class RunnerConnector(phantom.BaseConnector):
         response = None
         try:
             if self.session:
-                response = self.session.get(test_url, verify=False)
+                response = self.session.get(test_url, verify=self._verify_server_cert)
             else:
-                response = phantom.requests.get(test_url, verify=False)
+                response = phantom.requests.get(test_url, verify=self._verify_server_cert)
             self.__print(response.status_code, True)
         except:
             pass
@@ -498,6 +499,7 @@ class RunnerConnector(phantom.BaseConnector):
 
     def initialize(self):
         config = self.get_config()
+        self._verify_server_cert = config.get("verify_server_cert", True)
         try:
             self.print_debug = config.get("debug")
         except Exception as e:

--- a/runner_connector.py
+++ b/runner_connector.py
@@ -1,6 +1,6 @@
 # File: runner_connector.py
 #
-# Copyright (c) Mhike, 2022-2025
+# Copyright (c) Mhike, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Written by Codex.

## Summary

- add an asset-level `verify_server_cert` setting that defaults to enabled
- apply the configured TLS verification behavior to every authenticated Runner API request, including test connectivity
- refresh the shared connector tooling baseline and generated dependency metadata

## Tracking

- PAPP-38039
- PSAAS-30690
- VULN-93415
- FS-1485
- Epic: ESPM-5228

## Validation

- full pre-commit suite passed, including `package-app-dependencies` and `static-tests`
- `python3 -m py_compile runner_connector.py`
- `python3 -m json.tool runner.json`
- confirmed no remaining `verify=False` call sites
